### PR TITLE
Bunch of updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Worker options:
 
 ### Miscellaneous
 
-- `cluster`: expose the exported cluster module
+- `cluster`: expose node.js [cluster](https://nodejs.org/api/cluster.html) module
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 master-cluster is a utility to facilitate implementing node.js core [cluster](http://nodejs.org/api/cluster.html) module
 in any project. I created this module as I use the cluster module in pretty much all my projects and wanted to
-remove the boilerplate code. It implements node.js core [domain](http://nodejs.org/api/domain.html) module
-for correct exception handling. It also provides hot reloading of files on the worker in development mode
+remove the boilerplate code. It also provides hot reloading of files on the worker in development mode
 so that workers are restarted when code is changed.
 
 ## Usage
@@ -24,8 +23,7 @@ In `server.js`:
     MC.setFnHandlers(app.index, shutdown);
 
     // create the server and pass MC run handler
-    // each request will be wrap in a domain for exception handling
-    // so that workers are restarted automatically on crash
+    // workers are restarted automatically on crash
     var server = http.createServer(MC.run);
     server.listen(3000, function () {
       console.log("Listening on %d", 3000);
@@ -83,6 +81,7 @@ Following options can be passed to the master cluster configuration:
 - `size`: the number of workers to start, default is `require("os").cpus().length`
 - `reload`: `boolean`, default is `false` except when `/^dev/.test(process.env.NODE_ENV)`
 - `logger`: optional logger for errors (must implement `error` method)
+- `isCluster`: pass `false` to disable `cluster` and run master-only process. Setting `exec` is required in this case
 
 Reloader specific options:
 
@@ -98,10 +97,10 @@ Worker options:
 ### Method handlers
 
 - `start (options)`: start the master with cluster options
-- `run ()`: worker http handler that runs the request wrapped in the domain error handling
-- `setFnHandlers (runFn, errorFn)`: set the run and error handlers for the domain module
+- `run ()`: worker http handler that runs the request
+- `setFnHandlers (runFn, errorFn)`: set the run and error handlers
 - `setOptions (options)`: set the options for the workers (logger and kill timeout)
-- `createHttpServer (handler, port, onShutdown)`: create the http server and setup the run and error handlers for the domain module
+- `createHttpServer (handler, port, onShutdown)`: create the http server and setup the run and error handlers
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ console.log('Server listening on %d', 3000);
 
 Following options can be passed to the master cluster configuration:
 
-- `exec`: the code to run on the cluster master
+- `exec`: file path to worker file (see `exec` option of [cluster.setupMaster](https://nodejs.org/api/cluster.html#cluster_cluster_setupmaster_settings))
 - `size`: the number of workers to start, default is `require("os").cpus().length`
-- `reload`: `boolean`, default is `false` except when `process.env.NODE_ENV == 'dev'`
+- `reload`: `boolean`, default is `false` except when `/^dev/.test(process.env.NODE_ENV)`
 - `logger`: optional logger for errors (must implement `error` method)
 
 Reloader specific options:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ In `server.js`:
     var MC = require('master-cluster')
       , app = require('./app.js');
 
-    MC.createHttpServer(app.index, 3000, shutdown);
+    MC.createHttpServer(app.index, 3000, shutdown, function () {
+      console.log("Listening on %d", 3000);
+    });
 
     function shutdown () {
         // cleanly close db connections and other resources
@@ -100,7 +102,7 @@ Worker options:
 - `run ()`: worker http handler that runs the request
 - `setFnHandlers (runFn, errorFn)`: set the run and error handlers
 - `setOptions (options)`: set the options for the workers (logger and kill timeout)
-- `createHttpServer (handler, port, onShutdown)`: create the http server and setup the run and error handlers
+- `createHttpServer (handler, port, onShutdown, onListening)`: create the http server and setup the run and error handlers
 
 ### Miscellaneous
 

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -23,10 +23,6 @@ function start (options) {
 
   if (reload ) {
     reloader.reload(options);
-    cluster.reset = function () {
-      eachCluster(options.size, fork);
-      counter = 0;
-    }
   }
 
   eachCluster(options.size, fork);

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -21,7 +21,7 @@ function start (options) {
 
   cluster.setupMaster(options);
 
-  var counter = 0;
+  var counterReloadWorkerFails = 0;
   var reload = options.reload || options.reload === false ? options.reload : /^dev/.test(process.env.NODE_ENV);
 
   if (reload ) {
@@ -36,15 +36,18 @@ function start (options) {
       fork();
       return;
     }
-    if (counter > options.size * 3) {
+    if (counterReloadWorkerFails > options.size * 3) {
       logError('Application is crashing. Waiting for file change.');
       return;
     }
-    if (counter === 0)
+    if (counterReloadWorkerFails === 0)
+      // reset `counterReloadWorkerFails` in reload mode
+      // if there's no errors for more than 2 seconds
       setTimeout(function () {
-        counter = 0;
+        counterReloadWorkerFails = 0;
       }, 2000);
-    counter++;
+
+    counterReloadWorkerFails++;
     fork();
   });
 }

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -1,12 +1,14 @@
 'use strict';
 
+var assert = require('assert');
 var cluster = require('cluster');
 var debug = require('debug')('master-cluster');
 var reloader = require('./reloader');
 var setup = {};
 
 function start (options) {
-  if (! cluster.isMaster) throw new Error('Start can only be run on master!');
+  assert(cluster.isMaster, 'Start can only be run on master!');
+
   options = options || {};
   if (options.isCluster === false) {
     setup = options;
@@ -65,7 +67,7 @@ function fork () {
 }
 
 function run () {
-  if (typeof setup.run === 'undefined') throw new Error('There is nothing to run!');
+  assert(typeof setup.run === 'function', 'There is nothing to run!');
   if (typeof setup.error === 'undefined') setup.error = function () {};
 
   var d = require('domain').create(), args = arguments;

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -78,10 +78,12 @@ function run () {
   setup.run.apply(null, args);
 }
 
-function createHttpServer (handler, port, onShutdown) {
+function createHttpServer (handler, port, onShutdown, onListening) {
   var http = require('http');
   setFnHandlers (handler, onShutdown);
-  return http.createServer(run).listen(port);
+
+  if (!onListening) onListening = function () {}
+  return http.createServer(run).listen(port, onListening);
 }
 
 function setFnHandlers (runFn, errorFn) {

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -34,6 +34,10 @@ function start (options) {
 
   eachCluster(options.size, fork);
 
+  cluster.on('fork', function (worker) {
+    debug('Worker forked, id %d', worker.id);
+  });
+
   cluster.on('disconnect', function (worker) {
     debug('Worker %d with pid %s disconnected', worker.id, worker.process.pid);
     if (! reload) {
@@ -79,7 +83,7 @@ function run () {
   assert(typeof setup.run === 'function', 'There is nothing to run!');
 
   if (typeof setup.error === 'undefined') setup.error = noop;
-  setup.run.apply(null, args);
+  setup.run.apply(null, arguments);
 }
 
 function createHttpServer (handler, port, onShutdown, onListening) {

--- a/master-cluster.js
+++ b/master-cluster.js
@@ -11,8 +11,9 @@ function start (options) {
 
   options = options || {};
   if (options.isCluster === false) {
-    setup = options;
-    if (options.exec) require(options.exec);
+    assert(options.exec, 'exec option must be specified to run in non-cluster mode');
+
+    require(options.exec);
     return;
   }
   if (! options.size) options.size = require('os').cpus().length;
@@ -67,15 +68,11 @@ function fork () {
 }
 
 function run () {
+  assert(cluster.isWorker, 'run can be executed only inside worker process');
   assert(typeof setup.run === 'function', 'There is nothing to run!');
-  if (typeof setup.error === 'undefined') setup.error = function () {};
 
-  var d = require('domain').create(), args = arguments;
-  d.on('error', onWorkerError);
-  for (var i = 0; i < arguments.length; i++) d.add(arguments[i]);
-  d.run(function () {
-    setup.run.apply(this, args);
-  });
+  if (typeof setup.error === 'undefined') setup.error = function () {};
+  setup.run.apply(null, args);
 }
 
 function createHttpServer (handler, port, onShutdown) {


### PR DESCRIPTION
 * Remove `domain` module usage. This module is long time deprecated and it's not recommended for usage ([link 1](https://github.com/nodejs/node/issues/66#issuecomment-75359948), [link 2](http://stackoverflow.com/questions/33552400/why-is-domain-api-deprecated-in-node-js), [link 3](https://strongloop.com/strongblog/announcing-zones-for-node-js/)). Also if error occurs inside worker it will be disconnected and re-forked.
 * Add 4th option `isListening` to `MC.createHttpServer` so that it can be used as a 100% replacement of http.createServer or expressApp.listen (supports all of their API)
 * Document `isCluster` option
 * Use node.js `assert` instead of if..throw - this makes the code cleaner
 * Refactoring (`counter` renamed to `counterReloadWorkerFails`, noop used instead of empty functions)
 * Misc