### PR TITLE
Kill worker on reload

### DIFF
--- a/reloader.js
+++ b/reloader.js
@@ -50,10 +50,7 @@ function watch (path, rg) {
         debug('Killing worker %d', worker.id);
         worker.disconnect();
         var timeout = setTimeout(worker.kill.bind(worker), 3000);
-        worker.on('disconnect', function() {
-          clearTimeout(timeout);
-          worker.kill();
-        });
+        worker.on('exit', clearTimeout.bind(null, timeout));
       }
       catch (e) {
         debug('Error killing worker %d: %s', worker.id, e.message);

--- a/reloader.js
+++ b/reloader.js
@@ -50,7 +50,10 @@ function watch (path, rg) {
         debug('Killing worker %d', worker.id);
         worker.disconnect();
         var timeout = setTimeout(worker.kill.bind(worker), 3000);
-        worker.on('disconnect', clearTimeout.bind(null, timeout));
+        worker.on('disconnect', function() {
+          clearTimeout(timeout);
+          worker.kill();
+        });
       }
       catch (e) {
         debug('Error killing worker %d: %s', worker.id, e.message);


### PR DESCRIPTION
There's a race-condition in hot-reload. If disconnect-event fires before the timeout (which it almost always happens), the worker will never be killed.